### PR TITLE
Bump composer/installers to ~1.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
   "description": "WP Sync DB eliminates the manual work of migrating a WP database.",
   "keywords": ["plugin","wordpress","wp-sync-db","db"],
   "require": {
-    "composer/installers": "~1.0.6"
+    "composer/installers": "~1.0"
   },
   "scripts": {
     "test": "./test.sh"


### PR DESCRIPTION
Support any composer/installers version less than 2.0. Currently not possible to install with composer without this bump. See https://github.com/wp-sync-db/wp-sync-db/pull/138